### PR TITLE
Removes class check from Monk epic turn in

### DIFF
--- a/airplane/a_presence.lua
+++ b/airplane/a_presence.lua
@@ -7,7 +7,7 @@ end
 
 function event_trade(e)
 	local item_lib = require("items");
-	if((item_lib.check_turn_in(e.trade, {item1 = 1684})) and (e.other:GetLevel() >= 46) and (e.other:Class() == "Monk")) then
+	if((item_lib.check_turn_in(e.trade, {item1 = 1684})) and (e.other:GetLevel() >= 46)) then
 		e.self:Say("Hahaha! That dolt Eejag fell to the likes of you? Im not surprised. So, I guess this means you are here to challenge me. Normally, I wouldnt waste my time, but since you have defeated my younger brother, I suppose Im obligated.");
 		eq.depop_with_timer();
 		eq.spawn2(71069,0,0,e.self:GetX(),e.self:GetY(),-8,e.self:GetHeading()); -- NPC: Gwan

--- a/erudnext/Tomekeeper_Danl.lua
+++ b/erudnext/Tomekeeper_Danl.lua
@@ -1,6 +1,6 @@
 -- items: 18195, 1682, 48132
 function event_say(e)
-	if(e.other:GetLevel() >= 46 and e.other:Class() == "Monk") then
+	if(e.other:GetLevel() >= 46) then
 		local qglobals = eq.get_qglobals(e.other);
 		-- monk epic 1.0
 		if(e.message:findi("hail")) then
@@ -29,7 +29,7 @@ function event_trade(e)
 	local item_lib = require("items");
 	local qglobals = eq.get_qglobals(e.other);
 	
-	if(item_lib.check_turn_in(e.trade, {item1 = 18195}) and e.other:GetLevel() >= 46 and e.other:Class() == "Monk") then
+	if(item_lib.check_turn_in(e.trade, {item1 = 18195}) and e.other:GetLevel() >= 46) then
 		e.self:Emote("gasps at the sight of the rare book. 'This is a great find indeed! I can only imagine who you had to.. persuade to give you the book. Our library would be very interested in acquiring this and I am prepared to give you this referral that marks you as a friend of the library. If only [" .. eq.say_link("Lheao") .. "] could see this.'");
 		e.other:SummonItem(1682); -- Danl's Reference
 		e.other:Ding();

--- a/lakeofillomen/Astral_Projection.pl
+++ b/lakeofillomen/Astral_Projection.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 }
 
 sub EVENT_ITEM {
- if((plugin::check_handin(\%itemcount, 1687 => 1)) && ($ulevel>=46) && ($class=="Monk")){
+ if((plugin::check_handin(\%itemcount, 1687 => 1)) && ($ulevel>=46)){
    my $x = $npc->GetX();
    my $y = $npc->GetY();
    my $z = $npc->GetZ();

--- a/nurga/a_sleeping_ogre.pl
+++ b/nurga/a_sleeping_ogre.pl
@@ -16,7 +16,7 @@ sub EVENT_SAY {
 }
 
 sub EVENT_ITEM {
-  if((plugin::check_handin(\%itemcount, 1685 => 1)) && ($ulevel >= 46) && ($class eq "Monk")) { #Breath of Gwan
+  if((plugin::check_handin(\%itemcount, 1685 => 1)) && ($ulevel >= 46)) { #Breath of Gwan
     $npc->SetAppearance(0);
     quest::say("Your path of wanton destruction ends here. Gwan and Eejag were impatient and hot-headed. You will not defeat me, for I have the patience and perseverance of stone, unlike the children you have beaten before me. Are you sure you want to challenge me?");
     $trunt = quest::spawn2(107161,0,0,$x,$y,$z,$h); #Trunt

--- a/trakanon/#Kaiaren.pl
+++ b/trakanon/#Kaiaren.pl
@@ -21,15 +21,15 @@ sub EVENT_SAY {
 }
 
 sub EVENT_ITEM {
-  if((plugin::check_handin(\%itemcount, 1683 => 1)) && ($ulevel>=46) && ($class=="Monk")) { #Celestial Fists (Book)
+  if((plugin::check_handin(\%itemcount, 1683 => 1)) && ($ulevel>=46)) { #Celestial Fists (Book)
     quest::say("Now, then. Where did you find this, monk? This is not just some light reading to be borrowed from the town library. Who gave this to you?");
     quest::summonitem(1689); #Book of Celestial Fists
   }
-  elsif((plugin::check_handin(\%itemcount, 1684 => 1)) && ($ulevel>=46) && ($class=="Monk")) { #Charred Scale
+  elsif((plugin::check_handin(\%itemcount, 1684 => 1)) && ($ulevel>=46)) { #Charred Scale
     quest::say("Ahhh, impressive indeed! Now that you have broken the chain of the Fists, the others may come toppling down if you persevere. The Fist of Air is now the weakest, then Earth, and finally Water before the master of them all, Vorash. You must defeat them in order, proving the demise of the last to draw out the one you are after. The task before you now is to take this scale and show it to the Fist of Air wherever he may be. Good luck.");
     quest::summonitem(1684); #Charred Scale
   }
-  elsif((plugin::check_handin(\%itemcount, 1688 => 1, 1689 => 1)) && ($ulevel>=46) && ($class=="Monk")) { #Demon Fangs and Book of Celestial Fists
+  elsif((plugin::check_handin(\%itemcount, 1688 => 1, 1689 => 1)) && ($ulevel>=46)) { #Demon Fangs and Book of Celestial Fists
     quest::emote("bows his head and breathes a long sigh as if relived of a great weight. He then looks up at you and says, 'I honestly did not believe you could have defeated Vorash. Even though he sought nothing but war and bloodshed, it is a life nonetheless and we must mourn him. I will sew these fangs into magical fist wraps and they shall be yours. Remember Xenevorash. A purpose can be found for every situation and individual. To achieve perfection is to perceive this truth.'");
     quest::summonitem(10652); #Celestial Fists (Epic)
     quest::targlobal("MnkEpic1",1,"Y1",0000,$charid,000); #Flag for Monk Epic 1.0 completed

--- a/trakanon/Kaiaren.pl
+++ b/trakanon/Kaiaren.pl
@@ -12,17 +12,17 @@ sub EVENT_SAY {
 }
 
 sub EVENT_ITEM {
-  if((plugin::check_handin(\%itemcount, 1683 => 1)) && ($ulevel>=46) && ($class=="Monk")) { #Celestial Fists
+  if((plugin::check_handin(\%itemcount, 1683 => 1)) && ($ulevel>=46)) { #Celestial Fists
     quest::emote("eyes open wide and he attacks you!");
     quest::summonitem(1683); #Celestial Fists
     quest::attack($name);
     quest::spawn(95183,0,0,2470,306,-339); #Kaiaren (True)
   }
-  elsif((plugin::check_handin(\%itemcount, 1684 => 1)) && ($ulevel>=46) && ($class=="Monk")) { #Charred Scale
+  elsif((plugin::check_handin(\%itemcount, 1684 => 1)) && ($ulevel>=46)) { #Charred Scale
     quest::say("Ahhh, impressive indeed! Now that you have broken the chain of the Fists, the others may come toppling down if you persevere. The Fist of Air is now the weakest, then Earth, and finally Water before the master of them all, Vorash. You must defeat them in order, proving the demise of the last to draw out the one you are after. The task before you now is to take this scale and show it to the Fist of Air wherever he may be. Good luck.");
     quest::summonitem(1684); #Charred Scale
   }
-  elsif((plugin::check_handin(\%itemcount, 1688 => 1, 1689 => 1)) && ($ulevel>=46) && ($class=="Monk")) { #Demon Fangs and Book of Celestial Fists
+  elsif((plugin::check_handin(\%itemcount, 1688 => 1, 1689 => 1)) && ($ulevel>=46)) { #Demon Fangs and Book of Celestial Fists
     quest::emote("bows his head and breathes a long sigh as if relived of a great weight. He then looks up at you and says, 'I honestly did not believe you could have defeated Vorash. Even though he sought nothing but war and bloodshed, it is a life nonetheless and we must mourn him. I will sew these fangs into magical fist wraps and they shall be yours. Remember Xenevorash. A purpose can be found for every situation and individual. To achieve perfection is to perceive this truth.'");
     quest::summonitem(10652); #Celestial Fists (Epic)
     quest::targlobal("MnkEpic1",1,"Y1",0000,$charid,000); #Flag for Monk Epic 1.0 completed


### PR DESCRIPTION
This updates a few quests for the Monk epic which had conditional checks preventing turn ins from working for classes other than Monks (most importantly, Beastlords).