### PR TITLE
Fixes all remaining Monk epic quest checks

### DIFF
--- a/lakeofillomen/Deep.pl
+++ b/lakeofillomen/Deep.pl
@@ -12,7 +12,7 @@ sub EVENT_SPAWN {
 }
 
 sub EVENT_ENTER {
- if($class eq "Monk"){
+ if($class eq "Beastlord"){
   # Monk Epic 1.0
   quest::attack($name);
  }

--- a/lakeofillomen/Vorash.pl
+++ b/lakeofillomen/Vorash.pl
@@ -12,7 +12,7 @@ sub EVENT_SPAWN {
 }
 
 sub EVENT_ENTER {
- if(($class eq "Monk") && ($ulevel>=46)) {
+ if(($class eq "Beastlord") && ($ulevel>=46)) {
   # Monk Epic 1.0
   quest::attack($name);
  }

--- a/lakeofillomen/Xenevorash.pl
+++ b/lakeofillomen/Xenevorash.pl
@@ -6,7 +6,7 @@ sub EVENT_SPAWN {
 }
 
 sub EVENT_ENTER {
- if(($class eq "Monk") && ($ulevel>=46)){
+ if(($class eq "Beastlord") && ($ulevel>=46)){
   # Monk Epic 1.0
   quest::attack($name);
  }

--- a/lakerathe/Deep.pl
+++ b/lakerathe/Deep.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 }
 
 sub EVENT_ITEM {
-  if((plugin::check_handin(\%itemcount, 1686 => 1)) && ($ulevel >= 46) && ($class eq "Monk")) { #Trunt's Head
+  if((plugin::check_handin(\%itemcount, 1686 => 1)) && ($ulevel >= 46) && ($class eq "Beastlord")) { #Trunt's Head
     quest::emote("slowly opens her eyes and looks up at you. She stares at you a long while and then closes her eyes and lowers her head again.");
     quest::say("Very well, $name, if you wish death so greatly, we will be happy to oblige. My master projects part of himself in the wilder lands known as the Overthere. He has granted you an audience. Find him and show him the head of our earth brother. At that point, we will discuss how we will end your life.");
     quest::summonitem(1686); #Trunt's Head


### PR DESCRIPTION
Ughhhhh.

So, this step where you turn in the head to Deep in `lakerathe` isn't in the guide here https://www.eqprogression.com/monk-1-0-epic-quest/ so I didn't think it was needed.

Unfortunately, the PEQ version of the quest _does_ require it. So, it needs to be updated.

I also updated a few remaining checks for all of the quest NPCs in `lakeofillomen`. They _shouldn't_ be required but I'm going to just update every single thing I see to avoid having to do this again.